### PR TITLE
fix(skills): don't wipe unrelated skills when syncing dev skills

### DIFF
--- a/scripts/build-skills.ts
+++ b/scripts/build-skills.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { readSkills, renderSkill, writeFile, cleanDir } from './lib/utils.js';
+import { readSkills, renderSkill, writeFile, cleanDir, cleanManagedSkills } from './lib/utils.js';
 import { claudeCode } from './lib/transformers/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -30,7 +30,9 @@ writeFile(
 );
 console.log(`Skills hash: ${skillsHash}`);
 
-cleanDir(globalClaudeSkillsDir);
+// Only remove diffity's own dev skills, not the whole directory — ~/.claude/skills
+// is shared with the user's own skills and skills from other tools.
+cleanManagedSkills(globalClaudeSkillsDir, 'diffity-dev');
 for (const skill of skills) {
   claudeCode(skill, homeDir, { binary: 'diffity-dev', namePrefix: 'diffity-dev', slashPrefix: '/diffity-dev-', installHint: 'run `npm run dev` from the diffity repo root to link the CLI' });
 }

--- a/scripts/lib/utils.ts
+++ b/scripts/lib/utils.ts
@@ -68,3 +68,16 @@ export function cleanDir(dir: string): void {
   }
   mkdirSync(dir, { recursive: true });
 }
+
+// Remove only the skill directories diffity manages (those named `${prefix}-*`),
+// leaving any other skills in the directory untouched. Unlike cleanDir, this is
+// safe to run against a shared location like ~/.claude/skills, which may hold
+// the user's own skills or skills installed by other tools.
+export function cleanManagedSkills(dir: string, prefix: string): void {
+  mkdirSync(dir, { recursive: true });
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith(`${prefix}-`)) {
+      rmSync(join(dir, entry.name), { recursive: true, force: true });
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`npm run build:skills` calls `cleanDir(globalClaudeSkillsDir)` on `~/.claude/skills`, which **deletes the entire directory** before reinstalling diffity's dev skills.

This assumes diffity owns `~/.claude/skills` outright, but that directory is shared: it holds the user's own authored skills and skills installed by other tools. The blast radius is especially bad when `~/.claude/skills` is a symlink into a version-controlled dotfiles repo — running the build silently deletes the user's committed skills (and, with a bind-mounted home in a devcontainer, propagates the deletion to the host).

## Fix

Replace the blanket `cleanDir` with a new `cleanManagedSkills(dir, prefix)` helper that removes **only** the skill directories diffity manages (those named `diffity-dev-*`) and leaves everything else untouched. Stale diffity skills are still cleaned up between builds; unrelated skills survive.

## Testing

With unrelated skills present in `~/.claude/skills`, `npm run build:skills` now refreshes the `diffity-dev-*` skills while leaving the others in place.